### PR TITLE
Add boilerplate code for acm and dns entry for route53

### DIFF
--- a/ops/aws/modules/route53/acm.tf
+++ b/ops/aws/modules/route53/acm.tf
@@ -1,0 +1,16 @@
+resource "aws_acm_certificate" "acm_certificate" {
+  provider          = aws.virginia
+  domain_name       = var.url_address
+  validation_method = "DNS"
+  tags              = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "web_page" {
+  provider                = aws.virginia
+  certificate_arn         = aws_acm_certificate.acm_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation_route53_record : record.fqdn]
+}

--- a/ops/aws/modules/route53/dns.tf
+++ b/ops/aws/modules/route53/dns.tf
@@ -1,0 +1,33 @@
+data "aws_route53_zone" "web_page" {
+  name         = var.web_page
+  private_zone = false
+}
+
+resource "aws_route53_record" "validation_route53_record" {
+  for_each = {
+    for dvo in aws_acm_certificate.acm_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.web_page.zone_id
+}
+
+resource "aws_route53_record" "web_page_cname" {
+  zone_id = data.aws_route53_zone.web_page.zone_id
+  name    =  "amazon.lb.com" // URL of the load balancer
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.distribution.hosted_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/ops/aws/modules/route53/variables.tf
+++ b/ops/aws/modules/route53/variables.tf
@@ -1,0 +1,4 @@
+
+variable "web_page" {
+  type = string
+}


### PR DESCRIPTION
The pull request create boilerplate code route53 custom url. 
- It consist of ACM certificates.
- DNS entry for url
